### PR TITLE
Add dub config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.dub
+docs.json
+__dummy.html
+*.o
+*.obj

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: d
+script:
+- rdmd test/unittests.d

--- a/dub.json
+++ b/dub.json
@@ -1,0 +1,12 @@
+{
+	"name": "biod",
+	"authors": [
+		"Artem Tarasov",
+		"Pjotr Prins"
+	],
+	"description": "Bioinformatics library in D (utils for working with SAM, BAM, SFF formats)",
+	"copyright": "Copyright © 2016, BioD developers",
+	"license": "GPL",
+	"sourcePaths": ["bio"],
+	"importPaths": ["bio"]
+}


### PR DESCRIPTION
Fixes #18 

As said, adding support for dub really boils down to executing `dub init`. It is possible that you might want to tweak the `dub.json` a bit in later versions (e.g. it's "best practice" to put all source files in a `source` or `src` folder). Now you only need to register your package on code.dlang.org.
Please note that it is highly recommended to use versions for packages, so you might want to consider git tagging a `0.1` version.

You can find more information about the package format here: https://code.dlang.org/package-format?lang=json


Travis
--------

I also couldn't help myself and directly added a `.travis.yml`, so that you can test with CI in the future.
You only need to head over to Travis CI and enable the project.

In case you need more options, I wrote a small guide at the D wiki: https://wiki.dlang.org/Continuous_Integration