### PR TITLE
+ include the AH header tag to @SQ lines

### DIFF
--- a/bio/sam/header.d
+++ b/bio/sam/header.d
@@ -223,7 +223,8 @@ mixin HeaderLineStruct!("SqLine", "@SQ", "name",
           Field!("assembly", "AS"),
           Field!("md5", "M5"),
           Field!("species", "SP"),
-          Field!("uri", "UR"));
+          Field!("uri", "UR"),
+          Field!("AlternateHaplotype", "AH"));
 
 mixin HeaderLineStruct!("RgLine", "@RG", "identifier",
           Field!("identifier", "ID"),


### PR DESCRIPTION
This change keeps the 'AH' header tag in the resulting sorted BAM when invoking `sambamba sort`.

  - the "AH" header tag corresponds to Alternate Haplotypes in ALT
    mapping mode
  - based on samtools/hts-specs issue 147: https://github.com/samtools/hts-specs/pull/147
  - this tag is already being produced by `bwa` 0.7.15
      * see tag 0.7.15 (r1140) https://github.com/lh3/bwa/releases/tag/v0.7.15