### PR TITLE
fix deprecation warnings: integral promotion not done

### DIFF
--- a/bio/bam/read.d
+++ b/bio/bam/read.d
@@ -1007,7 +1007,7 @@ private:
         assert(n < 16);
         // http://graphics.stanford.edu/~seander/bithacks.html#ConditionalSetOrClearBitsWithoutBranching
         ushort mask = cast(ushort)(1 << n);
-        _flag = (_flag & ~mask) | ((-cast(int)b) & mask);
+        _flag = (_flag & ~cast(int)(mask)) | ((-cast(int)b) & mask);
     }
 
     // If _chunk is still a slice, not an array, duplicate it.

--- a/bio/core/utils/format.d
+++ b/bio/core/utils/format.d
@@ -58,7 +58,7 @@ private {
         char* wstr=str;
 
         static if (isSigned!T) { 
-            ulong uvalue = (value < 0) ? -value : value;
+            ulong uvalue = (value < 0) ? -cast(int)(value) : value;
         } else {
             ulong uvalue = value;
         }


### PR DESCRIPTION
This pull request fixes the following deprecation warnings: 
../bio/bam/read.d(1010): Deprecation: integral promotion not done ...