### PR TITLE
fixed deprecation warnings while running the benchmark

### DIFF
--- a/examples/calculate_gc_content_from_reference.d
+++ b/examples/calculate_gc_content_from_reference.d
@@ -8,7 +8,10 @@
 import bio.bam.reader;
 import bio.bam.md.reconstruct : dna;
 
-import std.stdio, std.datetime, std.range, std.array;
+import std.stdio;
+import std.datetime.stopwatch: benchmark, StopWatch;
+import std.range;
+import std.array;
 
 void main() {
   auto bam = new BamReader("../test/data/b7_295_chunk.bam");
@@ -31,10 +34,11 @@ void main() {
 
   auto reads = array(bam.reads); // no I/O during measurements
 
+  //std.datetime.stopwatch.StopWatch
   StopWatch sw; // for a range of reads, minumum number of MD tags is parsed
   sw.start(); walkLength(dna(reads)); sw.stop();
-  writeln("extracting reference from range of reads: ", sw.peek().usecs, "μs");
+  writeln("extracting reference from range of reads: ", sw.peek.total!"usecs", "μs");
   sw.reset(); 
   sw.start(); foreach (read; reads) walkLength(dna(read)); sw.stop();
-  writeln("extracting reference from each read:     ", sw.peek().usecs, "μs");
+  writeln("extracting reference from each read:     ", sw.peek.total!"usecs", "μs");
 }

--- a/examples/calculate_gc_content_from_reference.d
+++ b/examples/calculate_gc_content_from_reference.d
@@ -14,31 +14,38 @@ import std.range;
 import std.array;
 
 void main() {
-  auto bam = new BamReader("../test/data/b7_295_chunk.bam");
+    auto bam = new BamReader("../test/data/b7_295_chunk.bam");
 
-  // the sequence starts at first mapped base of first read
-  auto reference = dna(bam.reads);
+    // the sequence starts at first mapped base of first read
+    auto reference = dna(bam.reads);
 
-  int n_bases = 0, gc = 0;
+    int n_bases = 0, gc = 0;
 
-  foreach (base; reference) {
-    if (base == 'N') continue; // happens if coverage is zero
-    if (base == 'G' || base == 'C') gc += 1;
-    n_bases += 1;
-  }
+    foreach (base; reference) {
+        if (base == 'N') continue; // happens if coverage is zero
+        if (base == 'G' || base == 'C') gc += 1;
+        n_bases += 1;
+    }
 
-  writeln("total bases: ", n_bases);
-  writeln("        GC%: ", cast(float)gc / n_bases);
-  writeln("   sequence: ", reference);
-  writeln("     #reads: ", walkLength(bam.reads));
+    writeln("total bases: ", n_bases);
+    writeln("        GC%: ", cast(float)gc / n_bases);
+    writeln("   sequence: ", reference);
+    writeln("     #reads: ", walkLength(bam.reads));
 
-  auto reads = array(bam.reads); // no I/O during measurements
+    auto reads = array(bam.reads); // no I/O during measurements
 
-  //std.datetime.stopwatch.StopWatch
-  StopWatch sw; // for a range of reads, minumum number of MD tags is parsed
-  sw.start(); walkLength(dna(reads)); sw.stop();
-  writeln("extracting reference from range of reads: ", sw.peek.total!"usecs", "μs");
-  sw.reset(); 
-  sw.start(); foreach (read; reads) walkLength(dna(read)); sw.stop();
-  writeln("extracting reference from each read:     ", sw.peek.total!"usecs", "μs");
+    StopWatch sw; // for a range of reads, minimum number of MD tags is parsed
+
+    sw.start(); 
+    walkLength(dna(reads));
+    sw.stop();
+
+    writeln("extracting reference from range of reads: ", sw.peek.total!"usecs", "μs");
+
+    sw.reset(); 
+    sw.start(); 
+    foreach (read; reads) walkLength(dna(read)); 
+    sw.stop();
+
+    writeln("extracting reference from each read:     ", sw.peek.total!"usecs", "μs");
 }

--- a/examples/iterate_tags.d
+++ b/examples/iterate_tags.d
@@ -5,8 +5,10 @@
 // it is available on your path
 // Run example: rdmd -I.. -I../location_of_undead/src iterate_tags.d
 
-import bio.bam.reader, bio.bam.tagvalue;
-import std.stdio, std.datetime;
+import bio.bam.reader;
+import bio.bam.tagvalue;
+import std.stdio;
+import std.datetime.stopwatch : benchmark,StopWatch;
 import std.conv : to;
 
 void main() {
@@ -28,20 +30,29 @@ void main() {
   // It is not necessary to know exact value type as in BAM.
   // If it can be converted to specified type, that's fine.
   // Otherwise, an exception will be thrown.
-  auto v3 = to!long(v); auto v4 = to!string(v); auto v5 = to!float(v);
+  auto v3 = to!long(v); 
+  auto v4 = to!string(v); 
+  auto v5 = to!float(v);
 
   // With strings and arrays there is an unsafe but faster way...
   v = read["FZ"];
+  
   StopWatch sw;
 
   // even with -O -release -inline this is slow
-  sw.start; auto fz1 = to!(ushort[])(v); sw.stop();
-  writeln("  safe conversion: ", sw.peek().usecs, "μs");
+  sw.start; 
+  auto fz1 = to!(ushort[])(v);
+  sw.stop();
+  
+  writeln("  safe conversion: ", sw.peek.total!"usecs", "μs");
   sw.reset();
 
   // this works because v starts in memory with a union
-  sw.start(); auto fz2 = *(cast(ushort[]*)(&v)); sw.stop();
-  writeln("unsafe conversion: ", sw.peek().usecs, "μs");
+  sw.start();
+  auto fz2 = *(cast(ushort[]*)(&v)); 
+  sw.stop();
+  
+  writeln("unsafe conversion: ", sw.peek.total!"usecs", "μs");
 
   assert(fz1 == fz2);
 }


### PR DESCRIPTION
1. Make use of explicit import statements in the examples. This makes it easy for beginners to see what modules are imported. 
2. Fixes: Deprecated symbols in std.datetime are currently scheduled to be removed from the documentation and fully removed from Phobos in October 2019.