### PR TITLE
Add new comparator for mates and HI tag

### DIFF
--- a/bio/bam/read.d
+++ b/bio/bam/read.d
@@ -1581,6 +1581,45 @@ unittest {
   assert(mixedStrCompare("1235", "1234") > 0);
 }
 
+// small utility function to get the value of the HI tag and return '0' 
+// if it is not defined
+private int getHI(R)(auto ref R r) 
+    if (isBamRead!R)
+{
+        auto v = r["HI"];
+        if (v.is_nothing)
+            return 0;
+        return to!int(v);
+}
+
+/// $(P Comparison function for 'queryname' sorting order setting mates
+/// of the same alignments adjacent with the first mate coming before
+/// the second mate)
+bool compareReadNamesAndMates(R1, R2)(const auto ref R1 r1, const auto ref R2 r2) 
+    if (isBamRead!R1 && isBamRead!R2)
+{
+    if (r1.name == r2.name) {
+        if (getHI(r1) == getHI(r2))
+            return r1.flag() < r2.flag();
+        return getHI(r1) < getHI(r2);
+    }
+    return r1.name < r2.name;
+}
+
+/// $(P Comparison function for 'queryname' sorting order as in Samtools
+/// setting mates of the same alignments adjacent with the first mate 
+/// coming before the second mate)
+bool mixedCompareReadNamesAndMates(R1, R2)(const auto ref R1 r1, const auto ref R2 r2)
+    if (isBamRead!R1 && isBamRead!R2) 
+{
+    if (mixedStrCompare(r1.name, r2.name) == 0) {
+        if (getHI(r1) == getHI(r2))
+            return r1.flag() < r2.flag();
+        return getHI(r1) < getHI(r2);    
+    }
+    return mixedStrCompare(r1.name, r2.name) < 0;
+}
+
 /// $(P Comparison function for 'coordinate' sorting order
 /// (returns whether first read is 'less' than second))
 ///


### PR DESCRIPTION
This pull request adds two new versions of the `compareReadNames` and `mixedCompareReadNames` comparators that take into account the alignment index tag (`HI`) and put mates with the same `HI` adjacent.

This sorting method would be useful to prepare BAM files for [RSEM](https://deweylab.github.io/RSEM/) using sambamba.